### PR TITLE
Forward action check

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
-	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 )
 
 type targetsMock []targetMock
@@ -54,11 +54,11 @@ type elbv2Mock struct {
 	DescribeListenersError error
 }
 
-func NewDummyActions() []types.Action {
-	return []types.Action{
+func NewDummyActions() []elbv2Types.Action {
+	return []elbv2Types.Action{
 		{
-			ForwardConfig: &types.ForwardActionConfig{
-				TargetGroups: []types.TargetGroupTuple{
+			ForwardConfig: &elbv2Types.ForwardActionConfig{
+				TargetGroups: []elbv2Types.TargetGroupTuple{
 					{
 						TargetGroupArn: aws.String("oldTarget"),
 						Weight:         aws.Int32(50),
@@ -81,7 +81,7 @@ func (m elbv2Mock) ModifyRule(ctx context.Context, params *elbv2.ModifyRuleInput
 }
 func (m elbv2Mock) DescribeRules(ctx context.Context, params *elbv2.DescribeRulesInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeRulesOutput, error) {
 	return &elbv2.DescribeRulesOutput{
-		Rules: []types.Rule{
+		Rules: []elbv2Types.Rule{
 			{
 				RuleArn: &params.RuleArns[0],
 				Actions: NewDummyActions(),
@@ -91,7 +91,7 @@ func (m elbv2Mock) DescribeRules(ctx context.Context, params *elbv2.DescribeRule
 }
 func (m elbv2Mock) DescribeListeners(ctx context.Context, params *elbv2.DescribeListenersInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeListenersOutput, error) {
 	return &elbv2.DescribeListenersOutput{
-		Listeners: []types.Listener{
+		Listeners: []elbv2Types.Listener{
 			{
 				ListenerArn:    &params.ListenerArns[0],
 				DefaultActions: NewDummyActions(),

--- a/apply_test.go
+++ b/apply_test.go
@@ -57,6 +57,7 @@ type elbv2Mock struct {
 func NewDummyActions() []elbv2Types.Action {
 	return []elbv2Types.Action{
 		{
+			Type: elbv2Types.ActionTypeEnumForward,
 			ForwardConfig: &elbv2Types.ForwardActionConfig{
 				TargetGroups: []elbv2Types.TargetGroupTuple{
 					{

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -75,7 +75,7 @@ func Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf(string(output))
+		fmt.Print(string(output))
 
 		return nil
 	case "version":

--- a/loadYaml.go
+++ b/loadYaml.go
@@ -2,7 +2,7 @@ package tentez
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -12,7 +12,7 @@ func NewFromYaml(filepath string) (t Tentez, err error) {
 		return nil, fmt.Errorf("filepath(-f option) must be set")
 	}
 
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return
 	}

--- a/tentez.go
+++ b/tentez.go
@@ -86,7 +86,7 @@ func (t tentez) Plan() error {
 		}
 	}
 
-	fmt.Fprintf(t.config.io.out, output.String())
+	fmt.Fprint(t.config.io.out, output.String())
 
 	return nil
 }

--- a/tentez_test.go
+++ b/tentez_test.go
@@ -32,13 +32,11 @@ func Example() {
 	if err != nil {
 		return
 	}
-	fmt.Printf(string(output))
+	fmt.Print(string(output))
 
 	data, ok := targetsData[tentez.TargetTypeAwsListener].([]tentez.AwsListenerData)
 	if ok && len(data) > 0 {
 		name := data[0].Name
 		fmt.Println(name)
 	}
-
-	return
 }


### PR DESCRIPTION
## issue
Listeners or rules which don't have forward action cause a panic.

```
$ tentez -f examples/samples/example.yaml get
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x7731db]

goroutine 1 [running]:
github.com/FeLvi-zzz/tentez.AwsListenerRules.fetchData({0xc0000f8c00, 0x2, 0x8000e0?}, {{{0x8c86a0, 0xc000003a40}}, {{0x8c4bc0, 0xc000014010}, {0x8c4be0, 0xc000014018}, {0x8c4be0, ...}}})
        /home/felvi/go/pkg/mod/github.com/!fe!lvi-zzz/tentez@v0.6.0/awsListenerRule.go:111 +0x83b
github.com/FeLvi-zzz/tentez.tentez.Get({0xc00019e540, {0xc0001ac000, 0x7, 0x7}, {{{0x8c86a0, 0xc000003a40}}, {{0x8c4bc0, 0xc000014010}, {0x8c4be0, 0xc000014018}, ...}}})
        /home/felvi/go/pkg/mod/github.com/!fe!lvi-zzz/tentez@v0.6.0/tentez.go:97 +0xe5
github.com/FeLvi-zzz/tentez/internal/cli.Run()
        /home/felvi/go/pkg/mod/github.com/!fe!lvi-zzz/tentez@v0.6.0/internal/cli/main.go:70 +0x171
main._main()
        /home/felvi/go/pkg/mod/github.com/!fe!lvi-zzz/tentez@v0.6.0/cmd/tentez/main.go:15 +0x19
main.main()
        /home/felvi/go/pkg/mod/github.com/!fe!lvi-zzz/tentez@v0.6.0/cmd/tentez/main.go:11 +0x19
```
