### PR TITLE
check default rule

### DIFF
--- a/awsListenerRule.go
+++ b/awsListenerRule.go
@@ -35,8 +35,13 @@ func (r AwsListenerRule) execSwitch(targetWeight Weight, isForce bool, cfg Confi
 		return err
 	}
 
+	rule := ruleData.Rules[0]
+	if rule.IsDefault {
+		return fmt.Errorf("this is a default listener rule. Use `aws_listeners`")
+	}
+
 	tgWeight := Weight{}
-	for _, action := range ruleData.Rules[0].Actions {
+	for _, action := range rule.Actions {
 		if action.Type != elbv2Types.ActionTypeEnumForward {
 			return fmt.Errorf("invalid action type: %s", action.Type)
 		}
@@ -109,6 +114,10 @@ func (rs AwsListenerRules) fetchData(cfg Config) (TargetsData, error) {
 	res := []AwsListenerRuleData{}
 
 	for _, rule := range rules {
+		if rule.IsDefault {
+			return nil, fmt.Errorf("%s is a default listener rule. Use `aws_listeners`", aws.ToString(rule.RuleArn))
+		}
+
 		for _, action := range rule.Actions {
 			targetGroupTuples := []AwsTargetGroupTuple{}
 


### PR DESCRIPTION
## issue
Trying to switch a default listener rule with `aws_listener_rules` causes an AWS API error.
```
$ go run cmd/tentez/main.go -f examples/samples/example.yaml apply
(snip)
2 / 7 steps
Switch old:new = 70:30
1. tk-web-listner-rules switched!
2. tk-web-listner-default-rule operation error Elastic Load Balancing v2: ModifyRule, https response error StatusCode: 400, RequestID: 7cfde0ee-975b-424b-9630-d3117e7c5dd5, OperationNotPermitted: Default rule '(listener arn)' cannot be modified
exit status 1
```

## after
```
$ go run cmd/tentez/main.go -f examples/samples/example.yaml apply
(snip)
2 / 7 steps
Switch old:new = 70:30
1. tk-web-listner-rules switched!
2. tk-web-listner-default-rule this is a default listener rule. Use `aws_listeners`
exit status 1

$ go run cmd/tentez/main.go -f examples/samples/example.yaml get
(listener rule arn) is a default listener rule. Use `aws_listeners`
exit status 1
```