### PR TITLE
multiple filepath generating config

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -161,21 +161,28 @@ func (c ChangeActions) IsUpdate() bool {
 	return len(c) == 1 && c[0] == ChangeActionUpdate
 }
 
-func GenerateConfigFromTerraformPlanJson(json TerraformPlanJson) (YamlStruct, error) {
-	awsListeners, err := getAwsListenersFromTerraformJson(json)
-	if err != nil {
-		return YamlStruct{}, err
-	}
+func GenerateConfigFromTerraformPlanJsons(jsons []TerraformPlanJson) (YamlStruct, error) {
+	allAwsListeners := []AwsListener{}
+	allAwsListenerRules := []AwsListenerRule{}
 
-	awsListenerRules, err := getAwsListenerRulesFromTerraformJson(json)
-	if err != nil {
-		return YamlStruct{}, err
+	for _, json := range jsons {
+		awsListeners, err := getAwsListenersFromTerraformJson(json)
+		if err != nil {
+			return YamlStruct{}, err
+		}
+		allAwsListeners = append(allAwsListeners, awsListeners...)
+
+		awsListenerRules, err := getAwsListenerRulesFromTerraformJson(json)
+		if err != nil {
+			return YamlStruct{}, err
+		}
+		allAwsListenerRules = append(allAwsListenerRules, awsListenerRules...)
 	}
 
 	return YamlStruct{
 		Steps:            defaultSteps,
-		AwsListeners:     awsListeners,
-		AwsListenerRules: awsListenerRules,
+		AwsListeners:     allAwsListeners,
+		AwsListenerRules: allAwsListenerRules,
 	}, nil
 }
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -219,71 +219,77 @@ func TestChangeActions_IsUpdate(t *testing.T) {
 
 func TestGenerateConfigFromTerraformPlanJson(t *testing.T) {
 	cs := []struct {
-		input    TerraformPlanJson
+		input    []TerraformPlanJson
 		expected YamlStruct
 		isError  bool
 	}{
 		{
-			input: TerraformPlanJson{
-				ResourceChanges: []ResourceChange{
-					{
-						Address: "other_resource_address",
-						Type:    "aws_hoge",
-						Change: Change{
-							Actions: []ChangeAction{
-								ChangeActionUpdate,
+			input: []TerraformPlanJson{
+				{
+					ResourceChanges: []ResourceChange{
+						{
+							Address: "other_resource_address",
+							Type:    "aws_hoge",
+							Change: Change{
+								Actions: []ChangeAction{
+									ChangeActionUpdate,
+								},
+								After: json.RawMessage(
+									([]byte)(`{}`),
+								),
+								Before: json.RawMessage(
+									([]byte)(`{}`),
+								),
 							},
-							After: json.RawMessage(
-								([]byte)(`{}`),
-							),
-							Before: json.RawMessage(
-								([]byte)(`{}`),
-							),
+						},
+						{
+							Address: "other_change_action_address",
+							Type:    "aws_lb_listener",
+							Change: Change{
+								Actions: []ChangeAction{
+									ChangeActionCreate,
+								},
+								After: json.RawMessage(
+									([]byte)(`{}`),
+								),
+								Before: json.RawMessage(
+									([]byte)(`{}`),
+								),
+							},
 						},
 					},
-					{
-						Address: "other_change_action_address",
-						Type:    "aws_lb_listener",
-						Change: Change{
-							Actions: []ChangeAction{
-								ChangeActionCreate,
+				},
+				{
+					ResourceChanges: []ResourceChange{
+						{
+							Address: "listener_address",
+							Type:    "aws_lb_listener",
+							Change: Change{
+								Actions: []ChangeAction{
+									ChangeActionUpdate,
+								},
+								After: json.RawMessage(
+									([]byte)(`{"arn":"listener_arn","default_action":[{"target_group_arn":"new_tg_arn"}]}`),
+								),
+								Before: json.RawMessage(
+									([]byte)(`{"arn":"listener_arn","default_action":[{"target_group_arn":"old_tg_arn"}]}`),
+								),
 							},
-							After: json.RawMessage(
-								([]byte)(`{}`),
-							),
-							Before: json.RawMessage(
-								([]byte)(`{}`),
-							),
 						},
-					},
-					{
-						Address: "listener_address",
-						Type:    "aws_lb_listener",
-						Change: Change{
-							Actions: []ChangeAction{
-								ChangeActionUpdate,
+						{
+							Address: "rule_address",
+							Type:    "aws_lb_listener_rule",
+							Change: Change{
+								Actions: []ChangeAction{
+									ChangeActionUpdate,
+								},
+								After: json.RawMessage(
+									([]byte)(`{"arn":"rule_arn","action":[{"target_group_arn":"new_tg_arn"}]}`),
+								),
+								Before: json.RawMessage(
+									([]byte)(`{"arn":"rule_arn","action":[{"target_group_arn":"old_tg_arn"}]}`),
+								),
 							},
-							After: json.RawMessage(
-								([]byte)(`{"arn":"listener_arn","default_action":[{"target_group_arn":"new_tg_arn"}]}`),
-							),
-							Before: json.RawMessage(
-								([]byte)(`{"arn":"listener_arn","default_action":[{"target_group_arn":"old_tg_arn"}]}`),
-							),
-						},
-					},
-					{
-						Address: "rule_address",
-						Type:    "aws_lb_listener_rule",
-						Change: Change{
-							Actions: []ChangeAction{
-								ChangeActionUpdate,
-							},
-							After: json.RawMessage(
-								([]byte)(`{"arn":"rule_arn","action":[{"target_group_arn":"new_tg_arn"}]}`),
-							),
-							Before: json.RawMessage(
-								([]byte)(`{"arn":"rule_arn","action":[{"target_group_arn":"old_tg_arn"}]}`),
-							),
 						},
 					},
 				},
@@ -315,7 +321,7 @@ func TestGenerateConfigFromTerraformPlanJson(t *testing.T) {
 	}
 
 	for _, c := range cs {
-		y, err := GenerateConfigFromTerraformPlanJson(c.input)
+		y, err := GenerateConfigFromTerraformPlanJsons(c.input)
 		if c.isError != (err != nil) {
 			t.Errorf("expected isError is %t, got %v", c.isError, err)
 		}


### PR DESCRIPTION
multiply filepaths when generation config.

for example:
```
$ cd foo
$ terraform plan -out tfplan && terraform show -json tfplan > tfplan.json

$ cd ../bar
$ terraform plan -out tfplan && terraform show -json tfplan > tfplan.json

$ cd ../
$ tentez generate-config tfplanjson -f ./foo/tfplan.json -f ./bar/tfplan.json -o tentez.yaml
```