### PR TITLE
Able to read dir when generating config

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -12,8 +12,8 @@ var applyCmd = &cobra.Command{
 # show plan and apply
 $ tentez -f ./examples/example.yaml apply`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filepath := cmd.Flag("filepath").Value.String()
-		t, err := tentez.NewFromYaml(filepath)
+		filename := cmd.Flag("filename").Value.String()
+		t, err := tentez.NewFromYaml(filename)
 		if err != nil {
 			return err
 		}
@@ -26,8 +26,8 @@ $ tentez -f ./examples/example.yaml apply`,
 }
 
 func init() {
-	applyCmd.Flags().StringVarP(&filepath, "filepath", "f", "", "config file for tentez")
-	if err := applyCmd.MarkFlagRequired("filepath"); err != nil {
+	applyCmd.Flags().StringVarP(&filename, "filename", "f", "", "config file for tentez")
+	if err := applyCmd.MarkFlagRequired("filename"); err != nil {
 		panic(err)
 	}
 

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var filepaths = []string{}
+var filenames = []string{}
 var output = ""
 
 var generateConfigCmd = &cobra.Command{
@@ -27,8 +27,8 @@ $ terraform plan -out tfplan && terraform show -json tfplan > tfplan.json
 $ tentez generate-config tfplanjson -f ./tfplan.json -o tentez.yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		tfplanjsons := []tentez.TerraformPlanJson{}
-		for _, filepath := range filepaths {
-			data, err := os.ReadFile(filepath)
+		for _, filename := range filenames {
+			data, err := os.ReadFile(filename)
 			if err != nil {
 				return fmt.Errorf("cannot read file: %w", err)
 			}
@@ -69,8 +69,8 @@ $ tentez generate-config tfplanjson -f ./tfplan.json -o tentez.yaml`,
 }
 
 func init() {
-	generateConfigCmd.PersistentFlags().StringArrayVarP(&filepaths, "filepath", "f", []string{}, "terraform plan json file")
-	if err := generateConfigCmd.MarkPersistentFlagRequired("filepath"); err != nil {
+	generateConfigCmd.PersistentFlags().StringArrayVarP(&filenames, "filename", "f", []string{}, "terraform plan json file")
+	if err := generateConfigCmd.MarkPersistentFlagRequired("filename"); err != nil {
 		panic(err)
 	}
 

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/FeLvi-zzz/tentez"
 	"github.com/spf13/cobra"
@@ -27,7 +28,29 @@ $ terraform plan -out tfplan && terraform show -json tfplan > tfplan.json
 $ tentez generate-config tfplanjson -f ./tfplan.json -o tentez.yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		tfplanjsons := []tentez.TerraformPlanJson{}
+		extendedFilenames := []string{}
+
 		for _, filename := range filenames {
+			fileInfo, err := os.Stat(filename)
+			if err != nil {
+				return fmt.Errorf("cannot read file: %w", err)
+			}
+
+			if !fileInfo.IsDir() {
+				extendedFilenames = append(extendedFilenames, filename)
+				continue
+			}
+
+			dirEntries, err := os.ReadDir(filename)
+			if err != nil {
+				return fmt.Errorf("cannot read dir: %w", err)
+			}
+			for _, e := range dirEntries {
+				extendedFilenames = append(extendedFilenames, filepath.Join(filename, e.Name()))
+			}
+		}
+
+		for _, filename := range extendedFilenames {
 			data, err := os.ReadFile(filename)
 			if err != nil {
 				return fmt.Errorf("cannot read file: %w", err)

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -15,8 +15,8 @@ var getCmd = &cobra.Command{
 # Show current state of targets
 $ tentez -f ./examples/example.yaml get`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filepath := cmd.Flag("filepath").Value.String()
-		t, err := tentez.NewFromYaml(filepath)
+		filename := cmd.Flag("filename").Value.String()
+		t, err := tentez.NewFromYaml(filename)
 		if err != nil {
 			return err
 		}
@@ -36,8 +36,8 @@ $ tentez -f ./examples/example.yaml get`,
 }
 
 func init() {
-	getCmd.Flags().StringVarP(&filepath, "filepath", "f", "", "config file for tentez")
-	if err := getCmd.MarkFlagRequired("filepath"); err != nil {
+	getCmd.Flags().StringVarP(&filename, "filename", "f", "", "config file for tentez")
+	if err := getCmd.MarkFlagRequired("filename"); err != nil {
 		panic(err)
 	}
 

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -12,8 +12,8 @@ var planCmd = &cobra.Command{
 # show plan
 $ tentez -f ./examples/example.yaml plan`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filepath := cmd.Flag("filepath").Value.String()
-		t, err := tentez.NewFromYaml(filepath)
+		filename := cmd.Flag("filename").Value.String()
+		t, err := tentez.NewFromYaml(filename)
 		if err != nil {
 			return err
 		}
@@ -23,8 +23,8 @@ $ tentez -f ./examples/example.yaml plan`,
 }
 
 func init() {
-	planCmd.Flags().StringVarP(&filepath, "filepath", "f", "", "config file for tentez")
-	if err := planCmd.MarkFlagRequired("filepath"); err != nil {
+	planCmd.Flags().StringVarP(&filename, "filename", "f", "", "config file for tentez")
+	if err := planCmd.MarkFlagRequired("filename"); err != nil {
 		panic(err)
 	}
 

--- a/internal/cli/rollback.go
+++ b/internal/cli/rollback.go
@@ -12,8 +12,8 @@ var rollbackCmd = &cobra.Command{
 # rollback
 $ tentez -f ./examples/example.yaml rollback`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		filepath := cmd.Flag("filepath").Value.String()
-		t, err := tentez.NewFromYaml(filepath)
+		filename := cmd.Flag("filename").Value.String()
+		t, err := tentez.NewFromYaml(filename)
 		if err != nil {
 			return err
 		}
@@ -23,8 +23,8 @@ $ tentez -f ./examples/example.yaml rollback`,
 }
 
 func init() {
-	rollbackCmd.Flags().StringVarP(&filepath, "filepath", "f", "", "config file for tentez")
-	if err := rollbackCmd.MarkFlagRequired("filepath"); err != nil {
+	rollbackCmd.Flags().StringVarP(&filename, "filename", "f", "", "config file for tentez")
+	if err := rollbackCmd.MarkFlagRequired("filename"); err != nil {
 		panic(err)
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var filepath = ""
+var filename = ""
 
 var rootCmd = &cobra.Command{
 	Use:   "tentez",

--- a/loadYaml.go
+++ b/loadYaml.go
@@ -7,12 +7,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func NewFromYaml(filepath string) (t Tentez, err error) {
-	if filepath == "" {
-		return nil, fmt.Errorf("filepath must be specified")
+func NewFromYaml(filename string) (t Tentez, err error) {
+	if filename == "" {
+		return nil, fmt.Errorf("filename must be specified")
 	}
 
-	data, err := os.ReadFile(filepath)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
be able to specify directory when `generate-config tfplanjson`.

for example:
```
$ mkdir jsons

$ cd foo
$ terraform plan -out tfplan && terraform show -json tfplan > ../jsons/foo_tfplan.json

$ cd ../bar
$ terraform plan -out tfplan && terraform show -json tfplan > ../jsons/bar_tfplan.json

$ cd ../
$ tentez generate-config tfplanjson -f ./jsons -o tentez.yaml
```