### PR TITLE
check target group health

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -47,7 +47,7 @@ func sleep(sec int, cfg Config) {
 		for {
 			select {
 			case t := <-ticker.C:
-				fmt.Fprintf(cfg.io.out, "\rRemain: %ds ", int(finishAt.Sub(t).Seconds()))
+				fmt.Fprintf(cfg.io.out, "\rRemain: %ds\033[K", int(finishAt.Sub(t).Seconds()))
 
 			case <-tickerStop:
 				fmt.Fprintln(cfg.io.out, "\a")
@@ -86,6 +86,9 @@ func execSwitch(targets map[TargetType]Targets, weight Weight, isForce bool, cfg
 				fmt.Fprintln(cfg.io.out, err.Error())
 			} else {
 				fmt.Fprintln(cfg.io.out, "switched!")
+				if err := target.checkHealth(weight, cfg); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/apply_test.go
+++ b/apply_test.go
@@ -3,7 +3,9 @@ package tentez
 import (
 	"bytes"
 	"context"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -32,6 +34,10 @@ func (t targetMock) execSwitch(targetWeight Weight, isForce bool, cfg Config) er
 		return SkipSwitchError{"the new weight target is smaller than current one."}
 	}
 
+	return nil
+}
+
+func (t targetMock) checkHealth(targetWeight Weight, cfg Config) error {
 	return nil
 }
 
@@ -102,6 +108,32 @@ func (m elbv2Mock) DescribeListeners(ctx context.Context, params *elbv2.Describe
 }
 func (m elbv2Mock) DescribeTargetGroups(ctx context.Context, params *elbv2.DescribeTargetGroupsInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeTargetGroupsOutput, error) {
 	return &elbv2.DescribeTargetGroupsOutput{}, m.DescribeListenersError
+}
+func (m elbv2Mock) DescribeTargetHealth(context.Context, *elbv2.DescribeTargetHealthInput, ...func(*elbv2.Options)) (*elbv2.DescribeTargetHealthOutput, error) {
+	rand.Seed(time.Now().UnixNano())
+	i := rand.Intn(2)
+	if i == 0 {
+		return &elbv2.DescribeTargetHealthOutput{
+			TargetHealthDescriptions: []elbv2Types.TargetHealthDescription{
+				{
+					TargetHealth: &elbv2Types.TargetHealth{
+						State: elbv2Types.TargetHealthStateEnumUnhealthy,
+					},
+				},
+			},
+		}, m.DescribeListenersError
+	} else {
+		return &elbv2.DescribeTargetHealthOutput{
+			TargetHealthDescriptions: []elbv2Types.TargetHealthDescription{
+				{
+					TargetHealth: &elbv2Types.TargetHealth{
+						State: elbv2Types.TargetHealthStateEnumHealthy,
+					},
+				},
+			},
+		}, m.DescribeListenersError
+
+	}
 }
 
 func TestExecSwitch(t *testing.T) {

--- a/awsListener.go
+++ b/awsListener.go
@@ -139,3 +139,7 @@ func (ls AwsListeners) targetsSlice() (targets []Target) {
 	}
 	return targets
 }
+
+func (l AwsListener) checkHealth(weight Weight, cfg Config) error {
+	return checkSwitchTargetGroupHealth(l.Switch, weight, cfg)
+}

--- a/awsListenerRule.go
+++ b/awsListenerRule.go
@@ -148,3 +148,7 @@ func (rs AwsListenerRules) targetsSlice() (targets []Target) {
 	}
 	return targets
 }
+
+func (r AwsListenerRule) checkHealth(weight Weight, cfg Config) error {
+	return checkSwitchTargetGroupHealth(r.Switch, weight, cfg)
+}

--- a/awsListenerRule_test.go
+++ b/awsListenerRule_test.go
@@ -186,3 +186,45 @@ func TestAwsListenerRules_fetchData(t *testing.T) {
 		}
 	}
 }
+
+func TestAwsListenerRule_checkHealth(t *testing.T) {
+	cases := []struct {
+		isError         bool
+		awsListenerRule AwsListenerRule
+		weight          Weight
+		elbv2Mock       elbv2Mock
+	}{
+		{
+			isError: false,
+			awsListenerRule: AwsListenerRule{
+				Name:   "success",
+				Target: "validTarget",
+				Switch: Switch{
+					Old: "oldTarget",
+					New: "newTarget",
+				},
+			},
+			weight: Weight{
+				Old: 50,
+				New: 50,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		err := c.awsListenerRule.checkHealth(c.weight, Config{
+			client: Client{
+				elbv2: c.elbv2Mock,
+			},
+			io: IOStreams{
+				in:  bytes.NewBufferString(""),
+				out: bytes.NewBufferString(""),
+				err: bytes.NewBufferString(""),
+			},
+		})
+
+		if c.isError != (err != nil) {
+			t.Errorf("%s: expect isError == %t, but got %v", c.awsListenerRule.Name, c.isError, err)
+		}
+	}
+}

--- a/awsListener_test.go
+++ b/awsListener_test.go
@@ -186,3 +186,45 @@ func TestAwsListeners_fetchData(t *testing.T) {
 		}
 	}
 }
+
+func TestAwsListener_checkHealth(t *testing.T) {
+	cases := []struct {
+		isError     bool
+		awsListener AwsListener
+		weight      Weight
+		elbv2Mock   elbv2Mock
+	}{
+		{
+			isError: false,
+			awsListener: AwsListener{
+				Name:   "success",
+				Target: "validTarget",
+				Switch: Switch{
+					Old: "oldTarget",
+					New: "newTarget",
+				},
+			},
+			weight: Weight{
+				Old: 50,
+				New: 50,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		err := c.awsListener.checkHealth(c.weight, Config{
+			client: Client{
+				elbv2: c.elbv2Mock,
+			},
+			io: IOStreams{
+				in:  bytes.NewBufferString(""),
+				out: bytes.NewBufferString(""),
+				err: bytes.NewBufferString(""),
+			},
+		})
+
+		if c.isError != (err != nil) {
+			t.Errorf("%s: expect isError == %t, but got %v", c.awsListener.Name, c.isError, err)
+		}
+	}
+}

--- a/awsTargetGroup.go
+++ b/awsTargetGroup.go
@@ -1,0 +1,77 @@
+package tentez
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2Types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+func checkSwitchTargetGroupHealth(targetSwitch Switch, weight Weight, cfg Config) error {
+	if weight.Old > 0 {
+		isHealthy := false
+		isNoTarget := false
+		var err error
+		for !isHealthy {
+			fmt.Fprintf(cfg.io.out, "\rwaiting Healthy... last check: %s", time.Now().Format("15:04:05"))
+			time.Sleep(1 * time.Second)
+
+			isHealthy, isNoTarget, err = checkTargetGroupHealth(targetSwitch.Old, cfg)
+			if err != nil {
+				return err
+			}
+		}
+		if isNoTarget {
+			fmt.Fprintln(cfg.io.out, "\rno old targets\033[K")
+		} else {
+			fmt.Fprintln(cfg.io.out, "\rOld Target Healthy!\033[K")
+		}
+	}
+
+	if weight.New > 0 {
+		isHealthy := false
+		isNoTarget := false
+		var err error
+
+		for !isHealthy {
+			fmt.Fprintf(cfg.io.out, "\rwaiting Healthy... last check: %s\033[K", time.Now().Format("15:04:05"))
+			time.Sleep(1 * time.Second)
+
+			isHealthy, isNoTarget, err = checkTargetGroupHealth(targetSwitch.New, cfg)
+			if err != nil {
+				return err
+			}
+		}
+		if isNoTarget {
+			fmt.Fprintln(cfg.io.out, "\rno new targets\033[K")
+		} else {
+			fmt.Fprintln(cfg.io.out, "\rNew Target Healthy!\033[K")
+		}
+	}
+
+	return nil
+}
+
+func checkTargetGroupHealth(arn string, cfg Config) (isHealthy bool, isNoTarget bool, err error) {
+	out, err := cfg.client.elbv2.DescribeTargetHealth(context.TODO(), &elbv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(arn),
+	})
+	if err != nil {
+		return false, false, err
+	}
+
+	if len(out.TargetHealthDescriptions) == 0 {
+		return true, true, nil
+	}
+
+	for _, t := range out.TargetHealthDescriptions {
+		if t.TargetHealth.State != elbv2Types.TargetHealthStateEnumHealthy {
+			return false, false, nil
+		}
+	}
+
+	return true, false, nil
+}

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type elbv2Client interface {
 	DescribeRules(ctx context.Context, params *elbv2.DescribeRulesInput, optFns ...func(*elbv2.Options)) (*elbv2.DescribeRulesOutput, error)
 	elbv2.DescribeListenersAPIClient
 	elbv2.DescribeTargetGroupsAPIClient
+	elbv2.DescribeTargetHealthAPIClient
 }
 
 type Client struct {

--- a/interface.go
+++ b/interface.go
@@ -3,6 +3,7 @@ package tentez
 type Target interface {
 	getName() string
 	execSwitch(weight Weight, isForce bool, cfg Config) error
+	checkHealth(weight Weight, cfg Config) error
 }
 type Targets interface {
 	targetsSlice() []Target


### PR DESCRIPTION
check target group health

```console
$ go run cmd/tentez/main.go apply -f examples/samples/example.yaml 
Plan:
1. pause
2. switch old:new = 70:30
  - hoge
3. sleep 10s
4. switch old:new = 30:70
  - hoge
5. sleep 10s
6. switch old:new = 0:100
  - hoge
7. sleep 10s

1 / 7 steps
Pause
enter "yes", continue steps.
If you'd like to interrupt steps, enter "quit".
> yes
continue step


2 / 7 steps
Switch old:new = 70:30
1. hoge switched!
Old Target Healthy!
New Target Healthy!
Switched at 2023-02-17 12:39:45


3 / 7 steps
Sleep 10s
Resume at 2023-02-17 12:39:55
Remain: 0s
Resume


4 / 7 steps
Switch old:new = 30:70
1. hoge switched!
Old Target Healthy!
New Target Healthy!
Switched at 2023-02-17 12:39:59


5 / 7 steps
Sleep 10s
Resume at 2023-02-17 12:40:09
Remain: 0s
Resume


6 / 7 steps
Switch old:new = 0:100
1. hoge switched!
New Target Healthy!
Switched at 2023-02-17 12:40:11


7 / 7 steps
Sleep 10s
Resume at 2023-02-17 12:40:21
Remain: 0s
Resume

Apply complete!
```
