### PR TITLE
Add go build flag: CGO_ENABLED=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-windows-amd64:
 build: $(BINARIES)
 
 $(BINARIES): $(GO_FILES)
-	go build -ldflags="-X github.com/FeLvi-zzz/tentez.Revision=$(shell git rev-parse --short HEAD)" -o $@-$(GOOS)-$(GOARCH)$(SUFFIX) $(@:$(BINDIR)/%=$(ROOT_PACKAGE)/cmd/%)
+	CGO_ENABLED=0 go build -ldflags="-X github.com/FeLvi-zzz/tentez.Revision=$(shell git rev-parse --short HEAD)" -o $@-$(GOOS)-$(GOARCH)$(SUFFIX) $(@:$(BINDIR)/%=$(ROOT_PACKAGE)/cmd/%)
 	
 clean:
 	rm $(BINARIES)*


### PR DESCRIPTION
- 一部の軽量Linux distribution等で動作しないケースが有るため、 `CGO_ENABLED=0` を追加し共有ライブラリへの依存をなくします