### PR TITLE
chore(release.yml): Update asset builder go version to v1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: "go.mod"
 
       - name: Install gobump
         run: go install github.com/x-motemen/gobump/cmd/gobump@latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          go-version: "1.21"
 
       - name: Run tests
         run: go test ./...
@@ -30,7 +29,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          go-version: "1.21"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -46,7 +44,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          go-version: "1.21"
+
+      - name: Download dependencies
+        run: go mod download
 
       - name: Build
         run: make build_all


### PR DESCRIPTION
- issue: https://github.com/FeLvi-zzz/tentez/actions/runs/7458657645/job/20293052337

- Fixed problem with asset build failure
  - Update asset builder go version to v1.21