### PR TITLE
Bump up docker base image

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags:
       - v*
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     tags:
       - v*
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS builder
+FROM golang:1.22 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64


### PR DESCRIPTION
- Bump up docker base image
  - v1.21 -> v1.22
- Use `pull_request` since `pull_request_target` does not clone with fork repo